### PR TITLE
fix: correct result editor width

### DIFF
--- a/jinja2_eval_web.py
+++ b/jinja2_eval_web.py
@@ -179,7 +179,7 @@ class JinjaHandler(BaseHTTPRequestHandler):
           indentWithTabs: false,
           tabSize: 2
         });
-        resultEditor.setSize("90 %", 1000);
+        resultEditor.setSize("90%", 1000);
 
         function sendRender() {
           $.post('/render', {


### PR DESCRIPTION
## Summary
- fix incorrect width value for result editor in Jinja2 evaluator

## Testing
- `python -m py_compile jinja2_eval_web.py`


------
https://chatgpt.com/codex/tasks/task_e_68920dbe07b483309a574ea5f72f2780