### PR TITLE
Fix Nginx header in TODO playbook

### DIFF
--- a/playbooks/TODO.yaml
+++ b/playbooks/TODO.yaml
@@ -22,7 +22,7 @@ PHP:
 Httpd:
   - Criar um exemplo com virtualhost
 
-Ngnix:
+Nginx:
   - Criar um exemplo com virtualhost
 
 Docker:


### PR DESCRIPTION
## Summary
- correct typo in TODO list: `Ngnix` -> `Nginx`

## Testing
- `yamllint playbooks/TODO.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921080809483308a3c7565fb80c1d5